### PR TITLE
Remove blank targets from links

### DIFF
--- a/src/components/appGrid.tsx
+++ b/src/components/appGrid.tsx
@@ -13,13 +13,7 @@ export default function AppGrid({ apps }: AppGridProps) {
         {apps.map((appArray) => (
           <Grid.Row stretched key={appArray[0].icon}>
             {appArray.map((app) => (
-              <Grid.Column
-                width={5}
-                as="a"
-                target="blank"
-                href={app.dest}
-                key={app.name}
-              >
+              <Grid.Column width={5} as="a" href={app.dest} key={app.name}>
                 <Icon name={app.icon as SemanticICONS} size="large" />
                 {app.name}
               </Grid.Column>

--- a/src/components/listLinks.tsx
+++ b/src/components/listLinks.tsx
@@ -17,7 +17,7 @@ export default function ListLinks({ links, title, titleDest }: ListLinksProps) {
         {links.map((link) => (
           <List.Item key={link.key}>
             <List.Content>
-              <List.Description as="a" target="blank" href={link.dest}>
+              <List.Description as="a" href={link.dest}>
                 {link.key}
               </List.Description>
             </List.Content>


### PR DESCRIPTION
Since the homepage is a 'new tab' page anyway, there is little point to having links open in new tabs on click.